### PR TITLE
retains open/closed status of the modal window across refreshes

### DIFF
--- a/src/favorite-setups.js
+++ b/src/favorite-setups.js
@@ -268,6 +268,7 @@
       closeButton.textContent = "x";
       closeButton.onclick = function () {
         document.body.removeChild(mainDiv);
+        localStorage.setItem('showSetups', "N") // retain previous open/close behaviour
       };
 
       topDiv.appendChild(closeButton);
@@ -779,8 +780,14 @@
         button.innerText = "Favorite Setups";
         button.addEventListener("click", function () {
           const existing = document.querySelector("#tsitu-fave-setups");
-          if (existing) existing.remove();
-          else render();
+          if (existing) {
+            localStorage.setItem('showSetups', "N");
+            existing.remove();
+          }
+          else {
+              localStorage.setItem('showSetups', "Y");
+              render();
+          };
         });
         button.addEventListener("contextmenu", function () {
           if (confirm("Toggle 'Favorite Setups' placement?")) {
@@ -802,8 +809,14 @@
         link.innerText = "[Favorite Setups]";
         link.addEventListener("click", function () {
           const existing = document.querySelector("#tsitu-fave-setups");
-          if (existing) existing.remove();
-          else render();
+          if (existing) {
+              localStorage.setItem('showSetups', "N"); // retain previous open/close behaviour
+              existing.remove();
+          }
+          else {
+              render();
+              localStorage.setItem('showSetups', "Y"); // retain previous open/close behaviour
+          };
           return false; // Prevent default link clicked behavior
         });
         link.addEventListener("contextmenu", function () {
@@ -818,6 +831,9 @@
       }
     }
   }
+  // retain previous open/close behaviour
+  var openedSettings = localStorage.getItem('showSetups');
+  if(openedSettings == "Y") render();
   injectUI();
 
   /**


### PR DESCRIPTION
If the modal window was last left open, it will continue to stay open when on mousehuntgame.com until it is closed. It will then remain closed in subsequent refreshes until opened up again.