### PR TITLE
Update Mapping Helper for new endpoint

### DIFF
--- a/src/mapping-helper.js
+++ b/src/mapping-helper.js
@@ -2,7 +2,7 @@
 // @name         MouseHunt - Mapping Helper
 // @author       Tran Situ (tsitu)
 // @namespace    https://greasyfork.org/en/users/232363-tsitu
-// @version      2.6.1
+// @version      2.6.2
 // @description  Map interface improvements (invite via Hunter ID, direct send SB+, TEM-based available uncaught map mice)
 // @match        http://www.mousehuntgame.com/*
 // @match        https://www.mousehuntgame.com/*
@@ -263,7 +263,7 @@
     const notifDiv = document.createElement("div");
     notifDiv.className = "notification active";
     notifDiv.style.left = "300px";
-    notifDiv.style.top = "-30px";
+    notifDiv.style.top = "-55px";
     notifDiv.style.background = backgroundColor;
     notifDiv.innerText = mouseList.length || 0;
 
@@ -415,8 +415,9 @@
         ".treasureMapRootView-tab.active"
       );
       if (tabHeader) {
-        mapName = tabHeader.querySelector(".treasureMapRootView-tab-name")
-          .textContent;
+        mapName = tabHeader.querySelector(
+          ".treasureMapRootView-tab-name"
+        ).textContent;
       } else {
         // Tab header disappears when only 1 map is open, so fall back to HUD label
         const hudLabel = document.querySelector(


### PR DESCRIPTION
- **Mapping Helper v2.6 (2020-11-29): Relic Hunter Season 8 fixes**
- **Mapping Helper v2.6.1 (2020-12-10): Added HUD label fallback for when only a single map is active**
- **Mapping Helper v2.6.2 (2021-08-15): Shifted notifDiv 25px up to make way for trap zoom button**
- **Update for new treasuremap_v2 endpoint**

The greasyfork had a few updates that this repo didn't reflect. Only the last commit is the changes for the new endpoint.  

Mostly refactored to use the HG util so any internal changes to API url won't break again.
